### PR TITLE
Add chattier backup scripts

### DIFF
--- a/backups/files/dump-database.sh
+++ b/backups/files/dump-database.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# shellcheck enable=avoid-nullary-conditions
+# shellcheck enable=check-set-e-suppressed
+
+set -euo pipefail
+
+#####
+# Arguments
+
+# This script expects a single argument, identifier, which corresponds to a
+# number of values in this and other scripts:
+#
+# 1. It names the configuration file within /opt/backups/lib.
+# 2. It names the subdirectory within the backup root (e.g., "/var/lib/backups/$identifier")
+# 3. It names the lockfile and log tag.
+readonly identifier="${1:?USAGE: $0 <identifier>}"
+
+#####
+# Configuration
+
+# Where to store backups.
+readonly backup_root='{{ backup_root }}'
+
+# Who to notify on backup failures
+readonly mail_to='{{ mail_to }}'
+
+# The sender of the notification email
+readonly mail_from='{{ mail_from }}'
+
+# If set (and not empty), send email on successful syncs (not just failures)
+readonly mail_on_success='{{ mail_on_success }}'
+
+#####
+# Runtime values
+
+# Name of the lockfile preventing overlapping runs of this script
+readonly lockfile="/var/run/database-$identifier-backup.lock"
+
+# Name of the script holding database-specific functions
+readonly config_file="/opt/backup/lib/$identifier.sh"
+
+# Name of the directory where backups for this database endpoint are stored
+readonly backup_dir="$backup_root/$identifier"
+
+# Name of the log file we copy output to
+logfile="$(mktemp --tmpdir "$identifier.log.XXXXXXXXXX")"
+
+# Open the log file as a file descriptor to pass into other commands
+# NB. Lockfile FD is 10
+exec 11>"$logfile"
+readonly log_fd=11
+
+# Dates and times for identifying generated files
+date="$(date +%Y-%m-%d)"
+timestamp="$date-$(date +%H-%M-%S)"
+
+#####
+# Functions
+#
+# Behavior used elsewhere in the script. Moved here to keep the main script
+# logic fairly concise.
+
+# Output an informational notice
+log_info() {
+  echo "[INFO]" "$@" >&$log_fd
+  logger --tag "$identifier" --id $$ -- "$*"
+}
+
+# Output an error message
+log_error() {
+  echo "[ERROR]" "$@" >&$log_fd
+  logger --tag "$identifier" --id $$ --priority user.err -- "$*"
+}
+
+# Notify backup failure via email
+notify_backup_status() {
+  local status="$1"
+  mailx -r "$mail_from" -s "$(hostname) database backup for $identifier: $status" "$mail_to" <"$logfile"
+}
+
+on_script_exit() {
+  # Save the script exit code so we don't clobber it with our commands.
+  exit=$?
+
+  # Explicitly let stuff fail here. This is the last function that runs, so we
+  # want to clean up as much as we can.
+  set +e
+  set +o pipefail
+
+  # Send notification emails on two occasions:
+  # 1. Something bad happened and we've trapped a failure exit, or
+  # 2. We were asked to send emails even on successes.
+  #
+  # Note that this happens first because otherwise we'll blow away the log file.
+  if test $exit -ne 0; then
+    notify_backup_status failure
+  elif test -n "$mail_on_success"; then
+    log_info "Mailing on success because \$mail_on_success=$mail_on_success, which is not empty"
+    notify_backup_status success
+  fi
+
+  # Clean up the files we generated
+  rm -f "$lockfile"
+  rm -f "$logfile"
+
+  return $exit
+}
+
+#####
+# Database dump script
+
+log_info "Sourcing file $config_file"
+
+# shellcheck disable=SC1090
+. "$config_file" 2>&$log_fd
+
+# Make sure the file we sourced works and exported the functions we expect
+startup_ok=1
+for expected in ping_server list_all_databases dump_database is_ignored_database; do
+  # Use `type -t` to determine
+  type="$(type -t "$expected")"
+  case "$type" in
+    '')
+      log_error "Function '$expected' not found"
+      startup_ok=
+      ;;
+
+    function)
+      # This is okay; we expect these to be functions
+      ;;
+
+    *)
+      # This is okay, but not expected
+      log_info "Note: Found '$expected' of type '$type' instead of function. This may or may not be okay."
+      ;;
+  esac
+done
+
+log_info "Pinging database to determine connectivity"
+if ! ping_server 2>&$log_fd; then
+  log_error "Failed to connect to database"
+  startup_ok=
+fi
+
+if test -z "$startup_ok"; then
+  log_error "Refusing to proceed due to failed startup"
+
+  # Notify manually of startup failures
+  notify_backup_status failure
+  exit 1
+fi
+
+# Open the lockfile and get an exclusive lock on it. If we can't, fail.
+exec 10<>"$lockfile"
+if ! flock --nonblock --exclusive 10; then
+  lock_contents="$(cat <&10)"
+  log_error "Could not obtain lock for $lockfile (lock contents: $lock_contents)"
+
+  # Notify backup failure manually: the cleanup trap isn't safe to run
+  notify_backup_status failure
+  exit 1
+fi
+
+# Annotate the lock now that we know we have it.
+echo "Started by pid $$ at $timestamp" >&10
+
+list_all_databases() {
+  true
+}
+
+# Now that we're running exclusively, register the script exit handler
+trap on_script_exit EXIT
+
+log_info "Determining databases to back up"
+databases=()
+while read -r line; do
+  if is_ignored_database "$line"; then
+    log_info "Ignoring database $line"
+  else
+    databases+=("$line")
+  fi
+done < <(list_all_databases 2>&$log_fd)
+
+# Flag to determine if the backup operation was successful
+backup_ok=1
+
+# Dump each database in serial. Even if one dump fails, we try to dump the others.
+for database in "${databases[@]}"; do
+  outfile="$backup_dir/$database-$date.sql.gz"
+
+  log_info "Dumping database $database to $outfile"
+  if ! dump_database "$database" 2>&$log_fd | gzip 2>&$log_fd >"$outfile"; then
+    log_error "Failed to dump $database to $outfile (exit code $?)"
+
+    backup_ok=
+    continue
+  fi
+
+  log_info "Backed up to $outfile"
+done
+
+if test -n "$backup_ok"; then
+  # Rotate backups if everything succeeded
+  log_info "Rotating backups in $backup_dir"
+  if ! find "$backup_dir" -type f -ctime +7 -delete 2>&$log_fd; then
+    # We don't consider backup rotation failure to be an email-worthy emergency: it will use slightly more disk space,
+    # but it is not as critical as failing to generate backups in the first place.
+    log_error "Failed to rotate backups (exit code $?)"
+  fi
+else
+  log_error "One or more databases failed to back up. Please see the log contents above this message."
+  log_error "NOTE: Backups have not been rotated."
+  exit 1
+fi

--- a/backups/files/dump-database.sh
+++ b/backups/files/dump-database.sh
@@ -37,7 +37,7 @@ readonly mail_on_success='{{ mail_on_success }}'
 readonly lockfile="/var/run/database-$identifier-backup.lock"
 
 # Name of the script holding database-specific functions
-readonly config_file="/opt/backup/lib/$identifier.sh"
+readonly config_file="/opt/backups/lib/$identifier.sh"
 
 # Name of the directory where backups for this database endpoint are stored
 readonly backup_dir="$backup_root/$identifier"

--- a/backups/files/mysql.lib.sh
+++ b/backups/files/mysql.lib.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#####
+# Configuration
+
+# Which MySQL host to target
+readonly mysql_host='{{ host }}'
+
+# Which MySQL port to target
+readonly mysql_port='{{ port }}'
+
+mysql_connect_args=(
+  --defaults-file=/root/.my.cnf
+  --host="$mysql_host"
+  --port="$mysql_port"
+)
+
+#####
+# Exported functions
+
+ping_server() {
+  mysql "${mysql_connect_args[@]}" --batch --execute ''
+}
+
+list_all_databases() {
+  mysql "${mysql_connect_args[@]}" \
+    --batch \
+    --skip-column-names \
+    --execute 'SHOW DATABASES'
+}
+
+dump_database() {
+  mysqldump "${mysql_connect_args[@]}" \
+    --single-transaction \
+    --opt \
+    "$1"
+}
+
+is_ignored_database() {
+  [[ "$1" =~ ^(information_schema|performance_schema|mysql|sys|tmp)$ ]]
+}

--- a/backups/files/postgres.lib.sh
+++ b/backups/files/postgres.lib.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#####
+# Configuration
+
+# Which Postgres host to target
+readonly postgres_host='{{ host }}'
+
+# Which Postgres port to target
+readonly postgres_port='{{ port }}'
+
+# Which Postgres user to log in as
+readonly postgres_user='{{ user }}'
+
+# Arguments for connecting to Postgres
+postgres_connect_args=(
+  --host="$postgres_host"
+  --port="$postgres_port"
+  --username="$postgres_user"
+
+  # Disable the password prompt for all Postgres commands. This is an unattended
+  # script and we should be relying solely on .pgpass
+  --no-password
+)
+
+ping_server() {
+  psql "${postgres_connect_args[@]}" --command ''
+}
+
+list_all_databases() {
+  psql "${postgres_connect_args[@]}" \
+    --no-align \
+    --tuples-only \
+    --command 'SELECT datname FROM pg_database WHERE NOT datistemplate'
+}
+
+dump_database() {
+  pg_dump "${postgres_connect_args[@]}" \
+    --format=plain \
+    --no-owner \
+    --no-privileges \
+    "$1"
+}
+
+is_ignored_database() {
+  [[ "$1" =~ ^(rdsadmin|postgres|master)$ ]]
+}

--- a/backups/init.sls
+++ b/backups/init.sls
@@ -1,0 +1,46 @@
+{% from 'backups/map.jinja' import backup_root, mail_on_success, mail_to, mail_from with context %}
+
+/opt/backups/bin:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+{# Create the database dump script, but do not mark it as executable #}
+/opt/backups/bin/dump-database.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 640
+    - source: salt://database/files/dump-database.sh
+    - template: jinja
+    - context:
+      - backup_root: {{ backup_root }}
+      - mail_on_success: {{ "True" if mail_on_success else '' }}
+    - require:
+      - file: /opt/backups/bin
+
+/opt/backups/lib:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+{# Create a database configuration script for each database host in the pillar #}
+{% for identifier, data in salt['pillar.get']('backups:database:hosts', {}) %}
+/opt/backups/lib/{{ identifier }}.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 640
+    - source: salt://database/files/{{ data.type }}.lib.sh
+    - template: jinja
+    - context:
+        host: {{ data.host }}
+        port: {{ data.port }}
+        user: {{ data.get('user', '') }}
+    - require:
+      - file: /opt/backups/lib
+{% endfor %}

--- a/backups/map.jinja
+++ b/backups/map.jinja
@@ -1,0 +1,5 @@
+{% set backup_root = salt['pillar.get']('backups:dir', '/var/lib/backups') %}
+
+{% set mail_on_success = salt['pillar.get']('backups:mail:on_success', False) %}
+{% set mail_to = salt['pillar.get']('backups:mail:to', "sysadmins@forumone.com") %}
+{% set mail_from = salt['pillar.get']('backups:mail:from', "backups@byf1.dev") %}

--- a/rsyncnet/files/rsync-database.sh
+++ b/rsyncnet/files/rsync-database.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# shellcheck enable=avoid-nullary-conditions
+# shellcheck enable=check-set-e-suppressed
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+#####
+# Arguments
+
+# See database/files/dump-database.sh for more details on this argument
+readonly identifier="${1:?USAGE: $0 <identifier>}"
+
+#####
+# Configuration
+#
+# Variables here are configuration values determined by Salt.
+
+# Root directory for DB backups
+readonly backup_root='{{ backup_root }}'
+
+# Host to rsync to
+readonly rsync_host='{{ rsync_host }}'
+
+# Who to notify on backup failures
+readonly mail_to='{{ mail_to }}'
+
+# The sender of the notification email
+readonly mail_from='{{ mail_from }}'
+
+# If set (and not empty), send email on successful syncs (not just failures)
+readonly mail_on_success='{{ mail_on_success }}'
+
+#####
+# Runtime Values
+#
+# These are values used only by the script; don't change these unless you know
+# what you're doing.
+
+# Name of the directory where backups for this database host are stored
+readonly backup_dir="$backup_root/$identifier"
+
+# Name of the lockfile preventing overlapping runs of this script
+readonly lockfile="/var/run/rsync-databse-$identifier.lock"
+
+# Name of the log file we copy output to
+logfile="$(mktemp --tmpdir "rsync-database-$identifier.log.XXXXXXXXXX")"
+
+# Open the log file as a file descriptor to pass into other commands
+# NB. Lockfile FD is 10
+exec 11>"$logfile"
+readonly log_fd=11
+
+# Dates and times for identifying generated files
+date="$(date +%Y-%m-%d)"
+timestamp="$date-$(date +%H-%M-%S)"
+
+#####
+# Functions
+#
+# Behavior used elsewhere in the script. Moved here to keep the main script
+# logic fairly concise.
+
+# Output an informational notice
+log_info() {
+  echo "[INFO]" "$@" >&$log_fd
+  logger --tag "rsync-database-$identifier" --id $$ -- "$*"
+}
+
+# Output an error message
+log_error() {
+  echo "[ERROR]" "$@" >&$log_fd
+  logger --tag "rsync-database-$identifier" --id $$ --priority user.err -- "$*"
+}
+
+# Notify backup failure via email
+notify_backup_status() {
+  local status="$1"
+  mailx -r "$mail_from" -s "rsync backup $status: $identifier on $(hostname)" "$mail_to" <"$logfile"
+}
+
+# Pretty-print a duration (in seconds) as either "XXmYYs" or "XhYYmZZs",
+# depending on whether or not the duration is >1 hour.
+format_duration() {
+  local duration="$1"
+
+  local hours_in_seconds=3600
+  local hours=$((duration / hours_in_seconds))
+  duration=$((duration % hours_in_seconds))
+
+  local minutes_in_seconds=60
+  local minutes=$((duration / minutes_in_seconds))
+  duration=$((duration % minutes_in_seconds))
+
+  if test "$hours" -gt 0; then
+    printf "%dh%0dm%0ds" "$hours" "$minutes" "$duration"
+  else
+    printf "%0dm%0ds" "$minutes" "$duration"
+  fi
+}
+
+# Cleanup function. Once the lockfile is registered, this should be registered
+# as the EXIT trap in order to clean up resources regardless of when (and how)
+# the script exits.
+#
+# NB. It is NOT safe to register this handler until we know that we have a lock
+# on $lockfile.
+on_script_exit() {
+  # Save the script exit code so we don't clobber it with our commands.
+  exit=$?
+
+  # Explicitly let stuff fail here. This is the last function that runs, so we
+  # want to clean up as much as we can.
+  set +e
+  set +o pipefail
+
+  # Send notification emails on two occasions:
+  # 1. Something bad happened and we've trapped a failure exit, or
+  # 2. We were asked to send emails even on successes.
+  #
+  # Note that this happens first because otherwise we'll blow away the log file.
+  if test $exit -ne 0; then
+    notify_backup_status failure
+  elif test -n "$mail_on_success"; then
+    log_info "Mailing on success because \$mail_on_success=$mail_on_success, which is not empty"
+    notify_backup_status success
+  fi
+
+  # Clean up the files we generated
+  rm -f "$lockfile"
+  rm -f "$logfile"
+
+  return $exit
+}
+
+#####
+# Backups
+
+# Open the lockfile and get an exclusive lock on it. If we can't, fail.
+exec 10<>"$lockfile"
+if ! flock --nonblock --exclusive 10; then
+  lock_contents="$(cat <&10)"
+  log_error "Could not obtain lock for $lockfile (lock contents: $lock_contents)"
+
+  # Notify backup failure manually: the cleanup trap isn't safe to run
+  notify_backup_status failure
+  exit 1
+fi
+
+# Annotate the lock now that we know we have it.
+echo "Started by pid $$ at $timestamp" >&10
+
+# Now that we're running exclusively, register the script exit handler
+trap on_script_exit EXIT
+
+start="$(date +%s)"
+
+log_info "Running '/opt/backups/bin/dump-database.sh $identifier'; its status will be reported separately"
+bash "/opt/backups/bin/dump-database.sh" "$identifier"
+
+log_info "Syncing $backup_dir to rsync"
+rsync -arz --delete-after -e /usr/bin/ssh "$backup_dir" "$rsync_host:$backup_dir" 2>&$log_fd
+
+end="$(date +%s)"
+
+elapsed=$((end - start))
+log_info "Done in $(format_duration $elapsed)"

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# shellcheck enable=avoid-nullary-conditions
+# shellcheck enable=check-set-e-suppressed
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+#####
+# Configuration
+#
+# Variables here are configuration values determined by Salt.
+
+# Host to rsync to
+readonly rsync_host='{{ rsync_host }}'
+
+# File listing to use
+readonly rsync_payload='{{ rsync_payload }}'
+
+# Who to notify on backup failures
+readonly mail_to='{{ mail_to }}'
+
+# The sender of the notification email
+readonly mail_from='{{ mail_from }}'
+
+# If set (and not empty), send email on successful syncs (not just failures)
+readonly mail_on_success='{{ mail_on_success }}'
+
+#####
+# Runtime Values
+#
+# These are values used only by the script; don't change these unless you know
+# what you're doing.
+
+# Determines if this is the first run of rsync or not
+readonly rsync_first_run='/root/.rsync_first_run'
+
+# Name of the lockfile preventing overlapping runs of this script
+readonly lockfile="/var/run/rsync-files.lock"
+
+# Name of the log file we copy output to
+logfile="$(mktemp --tmpdir rsync-files.log.XXXXXXXXXX)"
+
+# Open the log file as a file descriptor to pass into other commands
+# NB. Lockfile FD is 10
+exec 11>"$logfile"
+readonly log_fd=11
+
+# The backup date. Used to identify both the OFS snapshot as well as archive tarballs.
+date="$(date +%Y-%m-%d)"
+
+# Timestamp used to identify archive tarballs
+timestamp="$date-$(date +%H-%M-%S)"
+
+#####
+# Functions
+#
+# Behavior used elsewhere in the script. Moved here to keep the main script
+# logic fairly concise.
+
+# Output an informational notice
+log_info() {
+  echo "[INFO]" "$@" >&$log_fd
+  logger --tag rsync-files --id $$ -- "$*"
+}
+
+# Output an error message
+log_error() {
+  echo "[ERROR]" "$@" >&$log_fd
+  logger --tag rsync-files --id $$ --priority user.err -- "$*"
+}
+
+# Notify backup status via email
+notify_backup_status() {
+  local status="$1"
+  mailx -r "$mail_from" -s "rsync backup $status: $(hostname)" "$mail_to" <"$logfile"
+}
+
+# Pretty-print a duration (in seconds) as either "XXmYYs" or "XhYYmZZs",
+# depending on whether or not the duration is >1 hour.
+format_duration() {
+  local duration="$1"
+
+  local hours_in_seconds=3600
+  local hours=$((duration / hours_in_seconds))
+  duration=$((duration % hours_in_seconds))
+
+  local minutes_in_seconds=60
+  local minutes=$((duration / minutes_in_seconds))
+  duration=$((duration % minutes_in_seconds))
+
+  if test "$hours" -gt 0; then
+    printf "%dh%0dm%0ds" "$hours" "$minutes" "$duration"
+  else
+    printf "%0dm%0ds" "$minutes" "$duration"
+  fi
+}
+
+# Cleanup function. Once the lockfile is registered, this should be registered
+# as the EXIT trap in order to clean up resources regardless of when (and how)
+# the script exits.
+#
+# NB. It is NOT safe to register this handler until we know that we have a lock
+# on $lockfile.
+on_script_exit() {
+  # Save the script exit code so we don't clobber it with our commands.
+  exit=$?
+
+  # Explicitly let stuff fail here. This is the last function that runs, so we
+  # want to clean up as much as we can.
+  set +e
+  set +o pipefail
+
+  # Unmount the snapshot before we send email, in order to report its status. It
+  # is not a catastrophe if the snapshot can't be unmounted (it can't be, here
+  # in this error handler), but it is worth surfacing.
+  if test -f /mnt/snapshot/README; then
+    log_info "Unmounting OFS snapshot"
+    if ! umount /mnt/snapshot 2>&$log_fd; then
+      log_error "Failed to umount /mnt/snapshot"
+    fi
+  fi
+
+  # Send notification emails on two occasions:
+  # 1. Something bad happened and we've trapped a failure exit, or
+  # 2. We were asked to send emails even on successes.
+  #
+  # Note that this happens first because otherwise we'll blow away the log file.
+  if test $exit -ne 0; then
+    notify_backup_status failure
+  elif test -n "$mail_on_success"; then
+    log_info "Mailing on success because \$mail_on_success=$mail_on_success, which is not empty"
+    notify_backup_status success
+  fi
+
+  # Clean up the files we generated
+  rm -f "$lockfile"
+  rm -f "$logfile"
+
+  return $exit
+}
+
+#####
+# Sync script
+
+# Open the lockfile and get an exclusive lock on it. If we can't, fail.
+exec 10<>"$lockfile"
+if ! flock --nonblock --exclusive 10; then
+  lock_contents="$(cat <&10)"
+  log_error "Could not obtain lock for $lockfile (lock contents: $lock_contents)"
+
+  # Notify backup failure manually: the cleanup trap isn't safe to run
+  notify_backup_status failure
+  exit 1
+fi
+
+# Annotate the lock now that we know we have it.
+echo "Started by pid $$ at $timestamp" >&10
+
+# Now that we're running exclusively, register the script exit handler
+trap on_script_exit EXIT
+
+start="$(date +%s)"
+
+if test -f /mnt/snapshot/README; then
+  log_info "Unmounting stale snapshot mount"
+  umount /mnt/snapshot 2>&$log_fd
+fi
+
+log_info "Ensuring directory /mnt/snapshot exists"
+mkdir -p /mnt/snapshot 2>&$log_fd
+
+# Find and mount the latest OFS snapshot
+ofs_bucket="$(awk '$2 == "/var/www" { print $1 }' /etc/fstab)"
+if test -z "$ofs_bucket"; then
+  log_error "Failed to find OFS bucket mounted on /var/www"
+  exit 1
+fi
+
+# Make sure that what we found is actually an S3 bucket
+if [[ "$ofs_bucket" != s3://* ]]; then
+  log_error "/var/www is mounted to $ofs_bucket which is not an S3 bucket"
+  exit 1
+fi
+
+log_info "Found OFS bucket: $ofs_bucket"
+
+# Find the latest snapshot (-sz: list snapshots (-s) in UTC (-z)). The /^s3/
+# condition in awk avoids capturing the first line of output (the column names).
+ofs_snapshot="$(/sbin/mount.objectivefs list -sz "$ofs_bucket@$date" 2>&$log_fd | awk '/^s3/ { latest = $1 } END { print latest }')"
+if test -z "$ofs_snapshot"; then
+  log_error "Could not find OFS snapshot in $ofs_bucket matching date $date"
+  exit 1
+fi
+
+log_info "Mounting OFS snapshot $ofs_snapshot to /mnt/snapshot"
+/sbin/mount.objectivefs "$ofs_snapshot" "/mnt/snapshot" 2>&$log_fd
+
+# Validate
+if ! test -f "/mnt/snapshot/README"; then
+  log_error "Failed to validate mount of OFS snapshot $ofs_snapshot: no README present"
+  exit 1
+fi
+
+# Flag to determine if the sync succeeded or failed. We attempt every operation
+# and report failure in aggregate.
+sync_ok=1
+
+if test -f "$rsync_first_run"; then
+  log_info "Performing file sync"
+  if ! rsync -arz --delete-after -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+    log_error "Failed to rsync files from $rsync_payload to $rsync_host"
+    sync_ok=
+  fi
+
+  if ! rsync -arz --delete-after -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts" 2>&$log_fd; then
+    log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
+    sync_ok=
+  fi
+else
+  log_info "Performing first-run file sync"
+  if ! rsync -ar --whole-file -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+    log_error "Failed to rsync files from $rsync_payload to $rsync_host"
+    sync_ok=
+  fi
+
+  if ! rsync -ar --whole-file -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts" 2>&$log_fd; then
+    log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
+    sync_ok=
+  fi
+
+  # Note an error but don't bail; this is not considered catastrophic.
+  if ! touch "$rsync_first_run"; then
+    log_error "Failed to update $rsync_first_run"
+  fi
+fi
+
+if test -z "$sync_ok"; then
+  log_error "One or more sync operations failed."
+  exit 1
+fi
+
+end="$(date +%s)"
+
+elapsed=$((end - start))
+log_info "Done in $(format_duration $elapsed)"

--- a/rsyncnet/pillar.example
+++ b/rsyncnet/pillar.example
@@ -1,8 +1,51 @@
-rsync:
-  user: < USER >
-  dumpdbs: True
-  paths:
-    - /etc
-    - /srv
-    - /var/lib/mysqlbackups
-    - /var/www/vhosts
+backups:
+  mail:
+    # Optional
+    to: sysadmins@forumone.com
+    from: backups@byf1.dev
+
+    # Set to True to be notified regardless of backup script status. By default,
+    # this will only send mail on errors.
+    on_success: False
+
+  # Optional
+  dir: /var/lib/backups
+
+  database:
+    hosts:
+      # MySQL only needs host and port
+      mysql:
+        type: mysql
+        host: ro-mysql
+        port: 3306
+
+      # User is required for Postgres connections
+      postgres-prod:
+        type: postgres
+        host: ro-psql-prod
+        port: 5432
+        user: master
+
+      postgres-preprod:
+        type: postgres
+        host: ro-psql-preprod
+        port: 5432
+        user: master
+
+  rsync:
+    # Optional
+    host: usw-s007.rsync.net
+
+    # Optional
+    # Do not add /mnt/snapshot/vhosts or /var/www/vhosts; that path is synced specially using an OFS snapshot.
+    paths:
+      - /etc
+      - /srv
+
+    # Required
+    user: USER
+
+    # Optional
+    # Use this list to only sync some databases. If omitted, it will sync everything in backups:database:hosts.
+    databases:
+      - mysql


### PR DESCRIPTION
# About this Update

## Dump/Sync Scripts

There are three primary entrypoint scripts to look at:

1. `backups/files/dump-database.sh`, the script to dump a named database endpoint.
2. `rsyncnet/files/rsync-files.sh`, the script to sync files to rsync.net.
3. `rsyncnet/files/rsync-database.sh`, the script to sync dumps of a named database endpoint.

## Directory Layout

The directory `backups` contains generic database dump scripts. The primary entry point, `dump-database.sh`, requires a "configuration" script. See `mysql.lib.sh` and `postgres.lib.sh` for how these scripts are expected to behave (and which Jinja variables they receive). Note that the dump script is NOT marked as executable in the file system; this is a deliberate choice to force it to be used by a driver script (such as `rsync-database.sh` in the `rsyncnet` directory).

The directory `rsyncnet` includes scripts and states necessary to set up rsync.net configuration, as well as export data to the platform.

## Pillar Configuration

`rsyncnet/pillar.example` serves as a commented example of configuration using the new pillar structure. All pillar keys live under `backups:` now, which means that the simplest port of configuration from the old structure to the new one is as follows:

```diff
--- pillar.old  2022-05-17 13:50:30.541312012 -0400
+++ pillar.new  2022-05-17 13:51:21.601250860 -0400
@@ -1,7 +1,5 @@
-rsync:
-  user: 1234
-  dumpdbs: False
-  paths:
-    - /etc
-    - /var/backups
-    - /var/www/vhosts
+backups:
+  rsync:
+    user: 1234
+    paths:
+      - /etc
```

The path `/var/backups` is taken care of by the database dump scripts, and `/var/www/vhosts` is synced specially using an OFS snapshot.

### Dumping Databases

To include dumping databases, add a `databases:hosts:` pillar under `backups:`:

```yaml
backups:
  databases:
    hosts:
      mysql:
        type: mysql
        host: ro-mysql
        port: 3306

  rsync:
    user: 1234
    paths:
      - /etc
```

One database host must be present for each endpoint to be dumped. For most projects the `mysql:` block will suffice, but you can add others as needed:


```yaml
backups:
  databases:
    hosts:
      mysql:
        type: mysql
        host: ro-mysql
        port: 3306

      postgres-prod:
        type: postgres
        host: postgres.production.example.org
        port: 5432

  rsync:
    user: 1234
    paths:
      - /etc
```

Each host will be dumped independently of each other in parallel and synced once the database dump is done. This way, large databases don't impede smaller databases' progress (and vice versa).

## What to Check

Before approving this PR, ensure the following questions are answered:

* Are the pillar migration instructions clear?
* Are the scripts understandable?
* Is the `rsync` command being invoked appropriately?