### PR TITLE
Remove the inherit_errexit shell option

### DIFF
--- a/backups/files/dump-database.sh
+++ b/backups/files/dump-database.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # shellcheck enable=avoid-nullary-conditions
-# shellcheck enable=check-set-e-suppressed
 
 set -euo pipefail
 

--- a/rsyncnet/files/rsync-database.sh
+++ b/rsyncnet/files/rsync-database.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # shellcheck enable=avoid-nullary-conditions
-# shellcheck enable=check-set-e-suppressed
 
 set -euo pipefail
-shopt -s inherit_errexit
 
 #####
 # Arguments

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # shellcheck enable=avoid-nullary-conditions
-# shellcheck enable=check-set-e-suppressed
 
 set -euo pipefail
-shopt -s inherit_errexit
 
 #####
 # Configuration


### PR DESCRIPTION
I forgot to check if this was supported in Bash 4.2 (spoiler alert: it isn't).