### PR TITLE
Avoid triggering conditional checks

### DIFF
--- a/backups/files/dump-database.sh
+++ b/backups/files/dump-database.sh
@@ -175,7 +175,7 @@ while read -r line; do
     log_info "Ignoring database $line"
   else
     databases+=("$line")
-    ((database_count++))
+    database_count=$((database_count + 1))
   fi
 done < <(list_all_databases 2>&$log_fd)
 


### PR DESCRIPTION
Apparently... `(( foo ))` on a command by itself is a conditional check, and it was exiting with a 1 for some reason.