### PR TITLE
Ask rsync to create destination paths

### DIFF
--- a/rsyncnet/files/rsync-database.sh
+++ b/rsyncnet/files/rsync-database.sh
@@ -36,7 +36,7 @@ readonly mail_on_success='{{ mail_on_success }}'
 # what you're doing.
 
 # Name of the directory where backups for this database host are stored
-readonly backup_dir="$backup_root/$identifier"
+readonly backup_dir="$backup_root/$identifier/"
 
 # Name of the lockfile preventing overlapping runs of this script
 readonly lockfile="/var/run/rsync-databse-$identifier.lock"
@@ -157,7 +157,7 @@ log_info "Running '/opt/backups/bin/dump-database.sh $identifier'; its status wi
 bash "/opt/backups/bin/dump-database.sh" "$identifier"
 
 log_info "Syncing $backup_dir to rsync"
-rsync -arz --delete-after -e /usr/bin/ssh "$backup_dir" "$rsync_host:$backup_dir" 2>&$log_fd
+rsync -arz --delete-after --mkpath -e /usr/bin/ssh "$backup_dir" "$rsync_host:$backup_dir" 2>&$log_fd
 
 end="$(date +%s)"
 

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -205,23 +205,23 @@ sync_ok=1
 
 if test -f "$rsync_first_run"; then
   log_info "Performing file sync"
-  if ! rsync -arz --delete-after -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+  if ! rsync -arz --delete-after --mkpath -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
     log_error "Failed to rsync files from $rsync_payload to $rsync_host"
     sync_ok=
   fi
 
-  if ! rsync -arz --delete-after -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts" 2>&$log_fd; then
+  if ! rsync -arz --delete-after --mkpath -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts/" 2>&$log_fd; then
     log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
     sync_ok=
   fi
 else
   log_info "Performing first-run file sync"
-  if ! rsync -ar --whole-file -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+  if ! rsync -ar --whole-file --mkpath -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
     log_error "Failed to rsync files from $rsync_payload to $rsync_host"
     sync_ok=
   fi
 
-  if ! rsync -ar --whole-file -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts" 2>&$log_fd; then
+  if ! rsync -ar --whole-file --mkpath -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts/" 2>&$log_fd; then
     log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
     sync_ok=
   fi


### PR DESCRIPTION
Per the `rsync` man page:

```
       --mkpath
              Create a missing path component of the destination arg.  This allows rsync  to
              create  multiple  levels  of  missing destination dirs and to create a path in
              which to put a single renamed file.  Keep in mind that you'll need to supply a
              trailing  slash if you want the entire destination path to be treated as a di‐
              rectory when copying a single arg (making rsync behave the same  way  that  it
              would if the path component of the destination had already existed).

              For  example,  the  following creates a copy of file foo as bar in the sub/dir
              directory, creating dirs "sub" and "sub/dir" if either do not yet exist:

                  rsync -ai --mkpath foo sub/dir/bar

              If you instead ran the following, it  would  have  created  file  foo  in  the
              sub/dir/bar directory:

                  rsync -ai --mkpath foo sub/dir/bar/
```