### PR TITLE
Use mkdir (and local paths)

### DIFF
--- a/rsyncnet/files/rsync-database.sh
+++ b/rsyncnet/files/rsync-database.sh
@@ -39,7 +39,7 @@ readonly mail_on_success='{{ mail_on_success }}'
 readonly local_backup_dir="$backup_root/$identifier/"
 
 # Same as local_backup_dir, but with the leading / stripped off.
-readonly remote_backup_dir="${backup_root#/}"
+readonly remote_backup_dir="${local_backup_dir#/}"
 
 # Name of the lockfile preventing overlapping runs of this script
 readonly lockfile="/var/run/rsync-databse-$identifier.lock"

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -203,25 +203,28 @@ fi
 # and report failure in aggregate.
 sync_ok=1
 
+log_info "Ensuring /var/www/vhosts exists on the remote"
+ssh "$rsync_host" mkdir -p var/www/vhosts 2>&$log_fd
+
 if test -f "$rsync_first_run"; then
   log_info "Performing file sync"
-  if ! rsync -arz --delete-after --mkpath -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+  if ! rsync -arz --delete-after -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
     log_error "Failed to rsync files from $rsync_payload to $rsync_host"
     sync_ok=
   fi
 
-  if ! rsync -arz --delete-after --mkpath -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts/" 2>&$log_fd; then
+  if ! rsync -arz --delete-after -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:var/www/vhosts/" 2>&$log_fd; then
     log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
     sync_ok=
   fi
 else
   log_info "Performing first-run file sync"
-  if ! rsync -ar --whole-file --mkpath -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
+  if ! rsync -ar --whole-file -e /usr/bin/ssh --files-from="$rsync_payload" / "$rsync_host:" 2>&$log_fd; then
     log_error "Failed to rsync files from $rsync_payload to $rsync_host"
     sync_ok=
   fi
 
-  if ! rsync -ar --whole-file --mkpath -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:/var/www/vhosts/" 2>&$log_fd; then
+  if ! rsync -ar --whole-file -e /usr/bin/ssh /mnt/snapshot/vhosts "$rsync_host:var/www/vhosts/" 2>&$log_fd; then
     log_error "Failed to rsync files from /mnt/snapshot/vhosts to $rsync_host"
     sync_ok=
   fi


### PR DESCRIPTION
The `--mkpath` option isn't supported by our older `rsync` installations, so this PR just bypasses the whole mess and uses `mkdir -p` to create the directories.

Also it uses local paths correctly (hopefully).