### PR TITLE
Add optional weekly reporting functionality

### DIFF
--- a/backups/files/dump-database.sh
+++ b/backups/files/dump-database.sh
@@ -74,7 +74,15 @@ log_error() {
 # Notify backup failure via email
 notify_backup_status() {
   local status="$1"
-  mailx -r "$mail_from" -s "$(hostname) database backup for $identifier: $status" "$mail_to" <"$logfile"
+  local message
+
+  # e.g., "sitename.byf1.dev database backup for mysql: success"
+  message="$(hostname) database backup for $identifier: $status"
+
+  # Output the message to 'backup-status' syslog tag, in order to identify the
+  # status message for weekly reports.
+  logger --tag backup-status "$message"
+  mailx -r "$mail_from" -s "$message" "$mail_to" <"$logfile"
 }
 
 on_script_exit() {

--- a/backups/files/weekly-report.sh
+++ b/backups/files/weekly-report.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+#####
+# Configuration
+
+# Who gets sent this weekly report
+readonly mail_to='{{ mail_to }}'
+
+# The sender of the notification email
+readonly mail_from='{{ mail_from }}'
+
+#####
+# Runtime values
+
+# The timestamp we want journalctl to start looking at. Use 8 days in order to
+# allow for some overlap.
+since="$(date --date="-8 days" +%Y-%m-%d)"
+
+#####
+# Report script
+
+# The 'statuses' variable below is a multiline string resulting from querying
+# journald for the below conditions:
+#
+# 1. `--system` asks for the system-level journal (the default for root, but
+#    it's better to be explicit)
+# 2. `--no-pager` unconditionally prevents journalctl from using a pager.
+# 3. `--identifier=backup-status` asks for only messages matching the given syslog
+#    identifier.
+# 4. `--since="$since"` only searches for messages beginning with the formatted
+#    date.
+statuses="$(journalctl --system --no-pager --identifier=backup-status --since="$since")"
+
+(
+  echo "Weekly report for $(hostname)"
+  echo "About this message:"
+  echo
+  # Be kind to plain text output and respect the rulers here:
+  #
+  #    "0         1         2         3         4         5         6         7         8"
+  #    "012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+  echo "Each line below this section is a log message from this server's journald. The"
+  echo "first line is the time range searched by this report, followed by statuses"
+  echo "reported from backup scripts."
+  echo
+  echo "$statuses"
+  echo
+  echo "Missing entries in this output may be due to the given job still running or this"
+  echo "script failing to capture the output."
+) | mailx -r "$mail_from" -s "$(hostname) weekly report" "$mail_to"

--- a/backups/map.jinja
+++ b/backups/map.jinja
@@ -3,3 +3,5 @@
 {% set mail_on_success = salt['pillar.get']('backups:mail:on_success', False) %}
 {% set mail_to = salt['pillar.get']('backups:mail:to', "sysadmins@forumone.com") %}
 {% set mail_from = salt['pillar.get']('backups:mail:from', "backups@byf1.dev") %}
+
+{% set weekly_report = salt['pillar.get']('backups:weekly_report', False) %}

--- a/rsyncnet/files/rsync-database.sh
+++ b/rsyncnet/files/rsync-database.sh
@@ -77,7 +77,11 @@ log_error() {
 # Notify backup failure via email
 notify_backup_status() {
   local status="$1"
-  mailx -r "$mail_from" -s "rsync backup $status: $identifier on $(hostname)" "$mail_to" <"$logfile"
+  local message
+  message="$(hostname) rsync backup for $identifier: $status"
+
+  logger --tag backup-status "$message"
+  mailx -r "$mail_from" -s "$message" "$mail_to" <"$logfile"
 }
 
 # Pretty-print a duration (in seconds) as either "XXmYYs" or "XhYYmZZs",

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -129,11 +129,9 @@ on_script_exit() {
   # Note that this happens first because otherwise we'll blow away the log file.
   if test $exit -ne 0; then
     notify_backup_status failure
-    echo "rsync backup $status: $(hostname)"
   elif test -n "$mail_on_success"; then
     log_info "Mailing on success because \$mail_on_success=$mail_on_success, which is not empty"
     notify_backup_status success
-    echo "some thing easy to grep: success"
   fi
 
   # Clean up the files we generated

--- a/rsyncnet/files/rsync-files.sh
+++ b/rsyncnet/files/rsync-files.sh
@@ -70,7 +70,11 @@ log_error() {
 # Notify backup status via email
 notify_backup_status() {
   local status="$1"
-  mailx -r "$mail_from" -s "rsync backup $status: $(hostname)" "$mail_to" <"$logfile"
+  local message
+  message="$(hostname) rsync backup $status"
+
+  logger --tag backup-status "$message"
+  mailx -r "$mail_from" -s "$message" "$mail_to" <"$logfile"
 }
 
 # Pretty-print a duration (in seconds) as either "XXmYYs" or "XhYYmZZs",
@@ -125,9 +129,11 @@ on_script_exit() {
   # Note that this happens first because otherwise we'll blow away the log file.
   if test $exit -ne 0; then
     notify_backup_status failure
+    echo "rsync backup $status: $(hostname)"
   elif test -n "$mail_on_success"; then
     log_info "Mailing on success because \$mail_on_success=$mail_on_success, which is not empty"
     notify_backup_status success
+    echo "some thing easy to grep: success"
   fi
 
   # Clean up the files we generated

--- a/rsyncnet/pillar.example
+++ b/rsyncnet/pillar.example
@@ -11,6 +11,9 @@ backups:
   # Optional
   dir: /var/lib/backups
 
+  # Set to True to be sent a weekly message summarizing backup activity.
+  weekly_report: False
+
   database:
     hosts:
       # MySQL only needs host and port


### PR DESCRIPTION
This PR adds weekly reporting functionality, enabled with the `backups:weekly_report` pillar configuration value.  Weekly log messages are identified using the `backup-status` syslog tag and loaded using the weekly-report.sh script.