### PR TITLE
contents is the correct argument, not content.  

### DIFF
--- a/rsyncnet/init.sls
+++ b/rsyncnet/init.sls
@@ -45,7 +45,7 @@ ssh_config_exists:
     - user: root
     - group: root
     - mode: '0600'
-    - content: {{ rsync_paths | join("\n") | yaml_encode }}
+    - contents: {{ rsync_paths | join("\n") | yaml_encode }}
 
 /opt/rsync/bin:
   file.directory:


### PR DESCRIPTION
One last PR before the weekend arrives. 

Currently the formula is not writing out `/etc/rsync-backup.txt`, this should fix that.